### PR TITLE
Add placeholder WordPress structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # estudioveintitres
 Estudio Veintitres Wordpress website
+
+## WordPress placeholder
+
+This repository contains a minimal placeholder structure for a WordPress site. The full WordPress source is not included due to environment limitations. To obtain the latest WordPress release, run the following command in an environment with internet access:
+
+```bash
+curl -O https://wordpress.org/latest.zip
+unzip latest.zip
+```
+
+Then copy the extracted files into the `wordpress` directory.
+

--- a/wordpress/index.php
+++ b/wordpress/index.php
@@ -1,0 +1,6 @@
+<?php
+// Placeholder for WordPress front controller
+// This minimal file does not implement WordPress functionality.
+
+echo "WordPress placeholder";
+

--- a/wordpress/wp-config-sample.php
+++ b/wordpress/wp-config-sample.php
@@ -1,0 +1,11 @@
+<?php
+// Sample configuration file for WordPress placeholder
+// Replace these values with your database configuration
+
+define('DB_NAME', 'database_name_here');
+define('DB_USER', 'username_here');
+define('DB_PASSWORD', 'password_here');
+define('DB_HOST', 'localhost');
+
+// Other necessary WordPress settings would go here.
+

--- a/wordpress/wp-login.php
+++ b/wordpress/wp-login.php
@@ -1,0 +1,5 @@
+<?php
+// Placeholder login page for WordPress
+
+echo "Login page placeholder";
+


### PR DESCRIPTION
## Summary
- create a minimal WordPress placeholder directory
- add placeholder PHP files
- document how to download the real WordPress source

## Testing
- `apt-get update` *(fails: unable to connect to proxy)*